### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-gemfire-localconfig-connector/README.md
+++ b/spring-cloud-gemfire-localconfig-connector/README.md
@@ -9,7 +9,7 @@ Basically parses a url following this pattern:
     <host>[port]
 
 The spring cloud localconfig connector documentation quick start, at:
-http://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html#_local_configuration_connector
+https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html#_local_configuration_connector
 
 ..shows an example of configuring a local mysql backing service using a spring-cloud properties file:
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html ([https](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html) result 200).